### PR TITLE
Fixing curl noise link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bitangent Noise
 
-[Curl Noise](https://www.cct.lsu.edu/~fharhad/ganbatte/siggraph2007/CD2/content/papers/046-bridson.pdf) by Robert Bridson is a widely known method that can generate divergence-free noise. This divergence-free property makes it extremely suitable for driving particles to move like real fluid motion.
+[Curl Noise](https://www.cs.ubc.ca/~rbridson/docs/bridson-siggraph2007-curlnoise.pdf) by Robert Bridson is a widely known method that can generate divergence-free noise. This divergence-free property makes it extremely suitable for driving particles to move like real fluid motion.
 
 Here is another divergence-free noise generator that is **computationally cheaper** than curl noise. I thought it was new and named it **Bitangent Noise**, but later I found it was already invented by [Ivan DeWolf](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.93.7627&rep=rep1&type=pdf) in 2005. (I'm wondering why it is so less popular comparing to curl noise.)
 


### PR DESCRIPTION
Hi,

I found that the link to the curl noise paper was broken. It returns a 404 - Not Found status code to me.
I looked for another source, and found one which seems to be correct, and to feature the same paper.

Sincerely,
Antonio

(PS: I created a pull request without creating an "Issue" to make fixing it as straight-forward as possible)